### PR TITLE
Add fatals when required environment vars are unset

### DIFF
--- a/auth0_auth_context.go
+++ b/auth0_auth_context.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -23,10 +22,10 @@ type Auth0AuthContext struct {
 func NewAuth0AuthContext(config *Configuration) *Auth0AuthContext {
 	return &Auth0AuthContext{
 		Config:            config,
-		ClientID:          os.Getenv("AUTH0_CLIENT_ID"),
-		ClientSecret:      os.Getenv("AUTH0_CLIENT_SECRET"),
-		AuthDomain:        os.Getenv("AUTH0_DOMAIN"),
-		CallbackURL:       os.Getenv("AUTH0_CALLBACK_URL"),
+		ClientID:          GetenvOrDie("AUTH0_CLIENT_ID"),
+		ClientSecret:      GetenvOrDie("AUTH0_CLIENT_SECRET"),
+		AuthDomain:        GetenvOrDie("AUTH0_DOMAIN"),
+		CallbackURL:       GetenvOrDie("AUTH0_CALLBACK_URL"),
 		ValidAccessTokens: map[string]string{},
 	}
 }

--- a/authentication_context.go
+++ b/authentication_context.go
@@ -1,6 +1,10 @@
 package authproxy
 
-import "net/http"
+import (
+	"log"
+	"net/http"
+	"os"
+)
 
 type AuthenticationContext interface {
 	IsAccessTokenValidAndUserAuthorized(accessToken string) bool
@@ -9,4 +13,16 @@ type AuthenticationContext interface {
 	GetCookieName() string
 	GetLoginPage() ([]byte, error)
 	ServeHTTP(w http.ResponseWriter, req *http.Request)
+}
+
+// GetenvOrDie is a safety wrapper around os.Getenv.
+// This fatals if the key is unset or empty.
+func GetenvOrDie(k string) string {
+	o := os.Getenv(k)
+
+	if o == "" {
+		log.Fatalf("%s environment variable missing and is required.", k)
+	}
+
+	return o
 }

--- a/github_auth_context.go
+++ b/github_auth_context.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -27,8 +26,8 @@ type GithubAuthRequest struct {
 
 func NewGithubAuthContext(config *Configuration) *GithubAuthContext {
 	return &GithubAuthContext{
-		ClientID:          os.Getenv("CLIENT_ID"),
-		ClientSecret:      os.Getenv("CLIENT_SECRET"),
+		ClientID:          GetenvOrDie("CLIENT_ID"),
+		ClientSecret:      GetenvOrDie("CLIENT_SECRET"),
 		Config:            config,
 		ValidAccessTokens: map[string]string{},
 	}


### PR DESCRIPTION
- Add GetenvOrDie() to fatal if os.Getenv() returns empty string.

This GetenvOrDie method allows us to remain inline on the \*AuthContext creation, but still not allowing the values to be empty. Less code to check errors every step.